### PR TITLE
Add user settings endpoint

### DIFF
--- a/src/api/file/user_settings.py
+++ b/src/api/file/user_settings.py
@@ -1,0 +1,72 @@
+from pydantic import BaseModel, Field
+from fastapi import APIRouter, HTTPException, Depends
+from datetime import datetime
+from typing import Optional
+from src.services.database.users import get_user_by_email
+from src.services.database.user_settings import get_user_setting, create_user_setting, update_user_setting
+from src.api.auth.dependencies import get_current_user
+
+router = APIRouter(tags=["File"])
+
+class UserSettings(BaseModel):
+    hard_drive_path_selection: str = Field(..., description="Drive path", example="Volume/device_1")
+
+class UserSettingModel(BaseModel):
+    id: int = Field(..., description="id value of the user settings", example=1)
+    user_id: int = Field(..., description="user id value of the user", example=1)
+    hard_drive_path_selection: str = Field(..., description="hard drive path for user", example="Volume/device_1")
+    created_at: datetime = Field(..., description="created at timestamp", example="2025-01-01 10:10:10")
+    updated_at: datetime = Field(..., description="updated at timestamp", example="2025-01-01 10:10:10")
+
+@router.put('/')
+async def user_settings(
+        payload: UserSettings,
+        current_user: dict = Depends(get_current_user)
+    ):
+    """Create or Update User Settings based off email from cookie (access token)"""
+    
+    email = current_user.get("email")
+    user = get_user_by_email(email)
+    
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user_setting = get_user_setting(user.id)
+    if not user_setting:
+        create_user_setting({
+                            "user_id": user.id,
+                            "hard_drive_path_selection": payload.hard_drive_path_selection
+                            })
+        return {"status": "ok"}
+
+    update_user_setting({
+        "user_id": user.id,
+        "hard_drive_path_selection": payload.hard_drive_path_selection
+    }) 
+
+    return {"status": "ok"}
+
+@router.get('/', response_model=Optional[UserSettingModel])
+async def user_settings(
+        current_user: dict = Depends(get_current_user),
+    ):
+    """Get User Settings for the current user based off email from Cookie (access token)"""
+
+    email = current_user.get("email")
+    user = get_user_by_email(email)
+
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    user_setting = get_user_setting(user.id)
+
+    if not user_setting:
+        return None
+    
+    return UserSettingModel(
+        id=user_setting.id,
+        user_id=user_setting.user_id,
+        hard_drive_path_selection=user_setting.hard_drive_path_selection,
+        created_at=user_setting.created_at,
+        updated_at=user_setting.updated_at
+    )

--- a/src/services/database/user_settings.py
+++ b/src/services/database/user_settings.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timezone
+from src.services.database.db_service import get_connection
+
+class UserSetting:
+    def __init__(self, row, cursor):
+        if row is not None:
+            # Set each column as an attribute with its name from the cursor description
+            for idx, col in enumerate(cursor.description):
+                setattr(self, col[0], row[idx])
+
+def get_user_setting(id: str):
+    with get_connection() as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("""
+                    SELECT *
+                    FROM user_settings AS us
+                    WHERE us.user_id = :user_id
+                """,
+                {
+                    "user_id" : id
+                })
+        
+        user_setting = cursor.fetchone()
+
+        if user_setting is None:
+            return None
+
+        return UserSetting(user_setting, cursor)
+
+def create_user_setting(parameters):
+    with get_connection() as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("""
+                INSERT INTO user_settings (user_id, hard_drive_path_selection) 
+                VALUES (:user_id, :hard_drive_path_selection)
+                """,
+                parameters
+                )
+
+        conn.commit()
+
+def update_user_setting(parameters):
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        parameters["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        cursor.execute("""
+                UPDATE user_settings
+                SET hard_drive_path_selection = :hard_drive_path_selection, updated_at = :updated_at
+                WHERE user_id = :user_id 
+                """,
+                parameters
+                )
+        
+        conn.commit()

--- a/src/services/database/users.py
+++ b/src/services/database/users.py
@@ -1,0 +1,49 @@
+from src.services.database.db_service import get_connection
+
+class User:
+    def __init__(self, row, cursor):
+        if row is not None:
+            # Set each column as an attribute with its name from the cursor description
+            for idx, col in enumerate(cursor.description):
+                setattr(self, col[0], row[idx])
+
+def get_user_by_id(id: str):
+    with get_connection() as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("""
+                        SELECT *
+                        FROM users AS u
+                        WHERE u.id = :user_id
+                    """,
+                    {
+                        "user_id" : id
+                    })
+        
+        user = cursor.fetchone()
+
+        if user is None:
+            return None
+
+        return User(user, cursor)
+
+def get_user_by_email(email: str):
+    with get_connection() as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("""
+                        SELECT *
+                        FROM users AS u
+                        WHERE u.email = :email
+                    """,
+                    {
+                        "email" : email
+                    })
+        
+        user = cursor.fetchone()
+
+        if user is None:
+            return None
+
+        return User(user, cursor)
+        

--- a/tests/api/file/test_user_settings.py
+++ b/tests/api/file/test_user_settings.py
@@ -1,0 +1,99 @@
+from unittest.mock import patch, MagicMock
+from src.services.database.user_settings import UserSetting
+
+class TestUserSettingsAPI:
+    def test_create_user_settings__success(self, test_client, bypass_auth):
+        mock_user = MagicMock()
+        mock_user.id = 1
+        
+        payload = {"hard_drive_path_selection": "/Volumes/Drive1"}
+        
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=mock_user), \
+             patch('src.api.file.user_settings.get_user_setting', return_value=None), \
+             patch('src.api.file.user_settings.create_user_setting') as mock_create:
+            
+            response = test_client.put("/file/user_settings/", json=payload)
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            mock_create.assert_called_once_with({
+                "user_id": 1,
+                "hard_drive_path_selection": "/Volumes/Drive1"
+            })
+
+    def test_update_user_settings__success(self, test_client, bypass_auth):
+        mock_user = MagicMock()
+        mock_user.id = 1
+        
+        mock_user_setting = MagicMock()
+        
+        payload = {"hard_drive_path_selection": "/Volumes/Drive2"}
+        
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=mock_user), \
+             patch('src.api.file.user_settings.get_user_setting', return_value=mock_user_setting), \
+             patch('src.api.file.user_settings.update_user_setting') as mock_update:
+            
+            response = test_client.put("/file/user_settings/", json=payload)
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            mock_update.assert_called_once_with({
+                "user_id": 1,
+                "hard_drive_path_selection": "/Volumes/Drive2"
+            })
+
+    def test_create_user_settings__user_not_found(self, test_client, bypass_auth):
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=None):
+            response = test_client.put("/file/user_settings/", json={"hard_drive_path_selection": "/Volumes/Drive1"})
+            
+            assert response.status_code == 404
+            data = response.json()
+            assert data["detail"] == "User not found"
+
+    def test_get_user_settings__success(self, test_client, bypass_auth):
+        mock_row = (1, 1, "/Volumes/Drive1", "2024-01-01 10:00:00", "2024-01-01 10:00:00")
+        mock_cursor = MagicMock()
+        mock_cursor.description = [
+            ("id", None, None, None, None, None, None),
+            ("user_id", None, None, None, None, None, None), 
+            ("hard_drive_path_selection", None, None, None, None, None, None),
+            ("created_at", None, None, None, None, None, None),
+            ("updated_at", None, None, None, None, None, None)
+        ]
+        
+        mock_user_setting = UserSetting(mock_row, mock_cursor)
+        
+        mock_user = MagicMock()
+        mock_user.id = 1
+        
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=mock_user), \
+             patch('src.api.file.user_settings.get_user_setting', return_value=mock_user_setting):
+            
+            response = test_client.get("/file/user_settings/")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["hard_drive_path_selection"] == "/Volumes/Drive1"
+            assert data["user_id"] == 1
+
+    def test_get_user_settings__user_not_found(self, test_client, bypass_auth):
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=None):
+            response = test_client.get("/file/user_settings/")
+            
+            assert response.status_code == 404
+            data = response.json()
+            assert data["detail"] == "User not found"
+
+    def test_get_user_settings__no_settings(self, test_client, bypass_auth):
+        mock_user = MagicMock()
+        mock_user.id = 1
+        
+        with patch('src.api.file.user_settings.get_user_by_email', return_value=mock_user), \
+             patch('src.api.file.user_settings.get_user_setting', return_value=None):
+            
+            response = test_client.get("/file/user_settings/")
+            
+            assert response.status_code == 200
+            assert response.json() is None

--- a/tests/services/database/test_user_settings.py
+++ b/tests/services/database/test_user_settings.py
@@ -1,0 +1,156 @@
+from unittest.mock import patch, MagicMock
+from src.services.database.user_settings import get_user_setting, create_user_setting, update_user_setting
+
+class TestUserSettingsService:
+    def test_get_user_setting__success(self):
+        mock_row = (1, 1, "/Volumes/Drive1", "2024-01-01 10:00:00", "2024-01-01 10:00:00")
+        mock_cursor = MagicMock()
+        mock_cursor.description = [
+            ("id", None, None, None, None, None, None),
+            ("user_id", None, None, None, None, None, None),
+            ("hard_drive_path_selection", None, None, None, None, None, None),
+            ("created_at", None, None, None, None, None, None),
+            ("updated_at", None, None, None, None, None, None)
+        ]
+        mock_cursor.fetchone.return_value = mock_row
+        
+        with patch('src.services.database.user_settings.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user_setting = get_user_setting("1")
+            
+            assert user_setting is not None
+            assert user_setting.id == 1
+            assert user_setting.user_id == 1
+            assert user_setting.hard_drive_path_selection == "/Volumes/Drive1"
+            mock_cursor.execute.assert_called_once()
+
+    def test_get_user_setting__not_found(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        
+        with patch('src.services.database.user_settings.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user_setting = get_user_setting("999")
+            
+            assert user_setting is None
+
+    def test_create_user_setting__success(self):
+        mock_cursor = MagicMock()
+        
+        parameters = {
+            "user_id": "1",
+            "hard_drive_path_selection": "/Volumes/Drive1"
+        }
+        
+        with patch('src.services.database.user_settings.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            create_user_setting(parameters)
+            
+            assert mock_cursor.execute.call_count == 1
+            assert mock_conn.commit.call_count == 1
+            
+            # Verify the SQL query was called with correct parameters
+            call_args = mock_cursor.execute.call_args
+            sql_query = call_args[0][0]
+            query_params = call_args[0][1]
+            
+            assert "INSERT INTO user_settings" in sql_query
+            assert query_params["user_id"] == "1"
+            assert query_params["hard_drive_path_selection"] == "/Volumes/Drive1"
+
+    def test_update_user_setting__success(self):
+        mock_cursor = MagicMock()
+        
+        parameters = {
+            "user_id": "1",
+            "hard_drive_path_selection": "/Volumes/Drive2"
+        }
+        
+        with patch('src.services.database.user_settings.get_connection') as mock_get_conn, \
+             patch('src.services.database.user_settings.datetime') as mock_datetime:
+            
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            # Mock current datetime
+            mock_now = MagicMock()
+            mock_now.strftime.return_value = "2024-01-01 10:30:00.000"
+            mock_datetime.now.return_value = mock_now
+            
+            update_user_setting(parameters)
+            
+            assert mock_cursor.execute.call_count == 1
+            assert mock_conn.commit.call_count == 1
+            
+            # Verify the SQL query was called with correct parameters
+            call_args = mock_cursor.execute.call_args
+            sql_query = call_args[0][0]
+            query_params = call_args[0][1]
+            
+            assert "UPDATE user_settings" in sql_query
+            assert "SET hard_drive_path_selection = :hard_drive_path_selection" in sql_query
+            assert "updated_at = :updated_at" in sql_query
+            assert "WHERE user_id = :user_id" in sql_query
+            
+            assert query_params["user_id"] == "1"
+            assert query_params["hard_drive_path_selection"] == "/Volumes/Drive2"
+            assert "updated_at" in query_params
+
+    def test_update_user_setting__adds_updated_at(self):
+        mock_cursor = MagicMock()
+        
+        parameters = {
+            "user_id": "1",
+            "hard_drive_path_selection": "/Volumes/Drive3"
+        }
+        
+        with patch('src.services.database.user_settings.get_connection') as mock_get_conn, \
+             patch('src.services.database.user_settings.datetime') as mock_datetime:
+            
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            mock_now = MagicMock()
+            mock_now.strftime.return_value = "2024-01-01 11:00:00"
+            mock_datetime.now.return_value = mock_now
+            
+            update_user_setting(parameters)
+            
+            # Verify updated_at was added to parameters
+            call_args = mock_cursor.execute.call_args
+            query_params = call_args[0][1]
+            
+            assert query_params["updated_at"] == "2024-01-01 11:00:00"
+            assert query_params["user_id"] == "1"
+            assert query_params["hard_drive_path_selection"] == "/Volumes/Drive3"
+
+    def test_user_setting_class_attributes(self):
+        mock_row = (5, 2, "/Volumes/Drive4", "2024-01-01 09:00:00", "2024-01-01 09:15:00")
+        mock_cursor = MagicMock()
+        mock_cursor.description = [
+            ("id", None, None, None, None, None, None),
+            ("user_id", None, None, None, None, None, None),
+            ("hard_drive_path_selection", None, None, None, None, None, None),
+            ("created_at", None, None, None, None, None, None),
+            ("updated_at", None, None, None, None, None, None)
+        ]
+        
+        from src.services.database.user_settings import UserSetting
+        user_setting = UserSetting(mock_row, mock_cursor)
+        
+        assert user_setting.id == 5
+        assert user_setting.user_id == 2
+        assert user_setting.hard_drive_path_selection == "/Volumes/Drive4"
+        assert user_setting.created_at == "2024-01-01 09:00:00"
+        assert user_setting.updated_at == "2024-01-01 09:15:00"

--- a/tests/services/database/test_users.py
+++ b/tests/services/database/test_users.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch, MagicMock
+from src.services.database.users import get_user_by_id, get_user_by_email
+
+class TestUsersService:
+    def test_get_user_by_id__success(self):
+        mock_row = (1, "test@example.com", "Test User", 0, 0, "2024-01-01 10:00:00")
+        mock_cursor = MagicMock()
+        mock_cursor.description = [
+            ("id", None, None, None, None, None, None),
+            ("email", None, None, None, None, None, None),
+            ("name", None, None, None, None, None, None),
+            ("is_admin", None, None, None, None, None, None),
+            ("is_guest", None, None, None, None, None, None),
+            ("created_at", None, None, None, None, None, None)
+        ]
+        mock_cursor.fetchone.return_value = mock_row
+        
+        with patch('src.services.database.users.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user = get_user_by_id("1")
+            
+            assert user is not None
+            assert user.id == 1
+            assert user.email == "test@example.com"
+            assert user.name == "Test User"
+            mock_cursor.execute.assert_called_once()
+
+    def test_get_user_by_id__not_found(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        
+        with patch('src.services.database.users.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user = get_user_by_id("999")
+            
+            assert user is None
+
+    def test_get_user_by_email__success(self):
+        mock_row = (1, "test@example.com", "Test User", 0, 0, "2024-01-01 10:00:00")
+        mock_cursor = MagicMock()
+        mock_cursor.description = [
+            ("id", None, None, None, None, None, None),
+            ("email", None, None, None, None, None, None),
+            ("name", None, None, None, None, None, None),
+            ("is_admin", None, None, None, None, None, None),
+            ("is_guest", None, None, None, None, None, None),
+            ("created_at", None, None, None, None, None, None)
+        ]
+        mock_cursor.fetchone.return_value = mock_row
+        
+        with patch('src.services.database.users.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user = get_user_by_email("test@example.com")
+            
+            assert user is not None
+            assert user.id == 1
+            assert user.email == "test@example.com"
+            assert user.name == "Test User"
+            mock_cursor.execute.assert_called_once()
+
+    def test_get_user_by_email__not_found(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None
+        
+        with patch('src.services.database.users.get_connection') as mock_get_conn:
+            mock_conn = MagicMock()
+            mock_conn.cursor.return_value = mock_cursor
+            mock_get_conn.return_value.__enter__.return_value = mock_conn
+            
+            user = get_user_by_email("nonexistent@example.com")
+            
+            assert user is None


### PR DESCRIPTION
In this PR, we are adding a User Settings endpoint to allow Users to eventually view the settings page and render their settings. Similar, we will allow users to update their settings which is why we create a POST request too. We are also establishing which user we are interacting with based on their cookie access token  